### PR TITLE
Renting services for Product Schema/Router

### DIFF
--- a/server/db/product/product.js
+++ b/server/db/product/product.js
@@ -65,6 +65,19 @@ ProductSchema.methods = {
   toggleActivation: function toggleActivation () {
     this.isActivated = !this.isActivated;
     return this;
+  },
+
+  rentalUpdate: function rentalUpdate (update) {
+      if (update.username !== undefined){
+      this.rentSchedule[0] = {
+        username: update.username,
+        from: "available",
+        to: "available"
+      };
+      return this;
+    } else {
+      throw err;
+    }
   }
 };
 

--- a/server/routes/products/products.js
+++ b/server/routes/products/products.js
@@ -63,4 +63,23 @@ router.put('/:id', expressJwt({secret: secret}), function(req, res){
   });
 });
 
+/**
+ *  Request Handler for PUT(update) Method with JWT verification middleware
+ *  @expected data with Req - 1. ObjectId as parameter(req.params.id)
+ *                            2. Complete product data including the field need to be updated(req.body)
+ *  @expected Header with Req - { "Authorization": "Bearer <JWT_TOKEN>"}
+ */
+router.put('/rent/:id', expressJwt({secret: secret}), function(req, res){
+  var id = req.params.id;
+  var update = req.body;
+  Product.findById(id, function(err, found){
+    found.rentalUpdate(update);
+    found.save()
+    .then(function(){
+      res.json(found);
+    });
+  });
+});
+
+
 module.exports = router;

--- a/server/routes/products/products.js
+++ b/server/routes/products/products.js
@@ -64,20 +64,28 @@ router.put('/:id', expressJwt({secret: secret}), function(req, res){
 });
 
 /**
- *  Request Handler for PUT(update) Method with JWT verification middleware
+ *  Request Handler for PUT(update rentSchedule) Method with JWT verification middleware
  *  @expected data with Req - 1. ObjectId as parameter(req.params.id)
- *                            2. Complete product data including the field need to be updated(req.body)
+ *                            2. If making new rental: {username: "available"} as body
+ *                            3. If removing existing rental: {username: renters-username} as body
  *  @expected Header with Req - { "Authorization": "Bearer <JWT_TOKEN>"}
+ *  @return {Object} - contains all product data including updated rentSchedule
  */
 router.put('/rent/:id', expressJwt({secret: secret}), function(req, res){
   var id = req.params.id;
   var update = req.body;
-  Product.findById(id, function(err, found){
-    found.rentalUpdate(update);
-    found.save()
-    .then(function(){
-      res.json(found);
-    });
+  Product.findById(id).then(function(found){
+    return found.rentalUpdate(update);
+  })
+  .then(function(updated){
+    return updated.save();
+  })
+  .then(function(saved){
+    res.json(saved);
+  })
+  .catch(function (err) {
+    console.log(err);
+    res.status(404).send('DatabaseError');
   });
 });
 

--- a/server/routes/profile/profile.js
+++ b/server/routes/profile/profile.js
@@ -42,4 +42,15 @@ router.put('/:id', expressJwt({secret: secret}), function(req, res){
   });
 });
 
+router.put('/rent/:id', expressJwt({secret: secret}), function(req, res){
+  var id = req.params.id;
+  var user = req.body;
+  User.findByIdAndUpdate(id, user).then(function () {
+    res.end();
+  }).catch(function (err) {
+    console.log(err);
+    res.status(404).send('weird....');
+  });
+});
+
 module.exports = router;

--- a/specs/server/ServerSpec.js
+++ b/specs/server/ServerSpec.js
@@ -274,5 +274,35 @@ describe('', function() {
         });
       });
     });
+
+    it('Be Able to Update Products Rental Schedule By Only Sending the productId and rentSchedule Object', function (done) {
+      var options1 = {
+        'method': 'PUT',
+        'headers': {
+          'Authorization': 'Bearer ' + tokenOfPhillip
+        },
+        'followAllRedirects': true,
+        'uri': 'http://localhost:' + port + '/products/rent/' + idOfSecondItem,
+        'json': {
+          username: 'notPhillip'
+        }
+      };
+      request(options1, function (err) {
+        if(err) return done(err);
+        request(options, function (err, res) {
+          if(err) return done(err);
+          var body = JSON.parse(res.body);
+          expect(res.statusCode).to.equal(200);
+          expect(body).to.have.lengthOf(2);
+          expect(body[1]).to.have.property('author');
+          expect(body[1].description).to.equal('Totally changed Description');
+          expect(body[1].rentSchedule[0].username).to.equal('notPhillip');
+          expect(body[1].rentSchedule[0].from).to.equal('available');
+          expect(body[1].rentSchedule[0].to).to.equal('available');
+          done();
+        });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Opening this pull request to discuss possible implementations.  I am thinking there are two options:
1) Add "availability" to product schema, with initial value set to "available".  If there is a rental, we re-use our Product Router "PUT" request method to update "availability" with renters unique username.  
- This version I think is the simplest to implement and requires the smallest of code.

2) Create new route products/rent/:id for a PUT request method.  We could create a method on the Product Schema that accepts either "username" or "makeAvailable" as inputs that will update the Product doc appropriately. 

I am thinking that number 1 is quick and easy (which is what I have done here) but some version of number 2 might be the best for db integrity and simplicity on the front end and I am leaning toward implementing number 2.  What do you think? Is there another option I am not thinking about?

-Also, once I have an approach nailed down, I will update/create new tests, as well as resolve the merge conflicts from the rentSchedule you just updated on staging.
